### PR TITLE
Fix nix-store.nix comments

### DIFF
--- a/modules/uncommon/nix-store.nix
+++ b/modules/uncommon/nix-store.nix
@@ -3,9 +3,9 @@
   # Dedupe the Nix store
   nix.settings.auto-optimise-store = true;
 
-  Garbage collection
+  # Garbage collection
   nix.gc.automatic = true;
   nix.gc.dates = "*-*-* 4:00:00";
-  without options it will only clean the store, not delete old generations
+  # without options it will only clean the store, not delete old generations
   nix.gc.options = "--delete-older-than 14d";
 }


### PR DESCRIPTION
## Summary
- comment stray description lines in nix-store module so file is valid Nix syntax

## Testing
- `nix --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fffebfd54832fab8220f4dfa4321b