### PR TITLE
Update comment on gnome keyring

### DIFF
--- a/modules/desktop-environment/gnome-config.nix
+++ b/modules/desktop-environment/gnome-config.nix
@@ -1,6 +1,6 @@
 { config, pkgs, lib, ... }:
 {
-  # Disable GNOME keyring
+  # Optionally disable GNOME keyring
   # services.gnome.gnome-keyring.enable = lib.mkForce false;
 
   # GNOME excludes


### PR DESCRIPTION
## Summary
- clarify that disabling GNOME keyring is optional

## Testing
- `nix --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffff356d0832fb093fd256f0b52db