### PR TITLE
Enable LaTeX module across hosts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
           ./modules/uncommon/virtualisation.nix
           ./modules/uncommon/wireshark.nix
           ./modules/uncommon/tpm.nix
+          ./modules/uncommon/latex.nix
           ./hosts/dell/hardware-configuration.nix
           home-manager.nixosModules.home-manager
           {
@@ -44,6 +45,7 @@
           ./modules/uncommon/virtualisation.nix
           ./modules/uncommon/wireshark.nix
           ./modules/uncommon/tpm.nix
+          ./modules/uncommon/latex.nix
           ./modules/uncommon/adguard.nix
           ./hosts/ptah/hardware-configuration.nix
           home-manager.nixosModules.home-manager


### PR DESCRIPTION
## Summary
- enable the existing `latex.nix` module for both hosts

## Testing
- `apt-get update`
- `nix flake check` *(fails: `bash: nix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840010761e0832fb11136f41c5270d6