### PR TITLE
Fix renamed GNOME and GDM options

### DIFF
--- a/modules/desktop-environment/display.nix
+++ b/modules/desktop-environment/display.nix
@@ -5,8 +5,8 @@
 
   # Enable the GNOME Desktop Environment
   services.displayManager.defaultSession = "gnome";
-  services.xserver.displayManager.gdm.enable = true;
-  services.xserver.desktopManager.gnome.enable = true;
+  services.displayManager.gdm.enable = true;
+  services.desktopManager.gnome.enable = true;
   # GNOME settings daemon
   services.udev.packages = with pkgs; [ gnome-settings-daemon ];
 }

--- a/modules/uncommon/wayland.nix
+++ b/modules/uncommon/wayland.nix
@@ -1,9 +1,9 @@
 { config, pkgs, ... }:
 {
-  services.xserver.displayManager.gdm.wayland = true;
+  services.displayManager.gdm.wayland = true;
   # Ozone and fractional scaling
   environment.sessionVariables.NIXOS_OZONE_WL = "1";
-  services.xserver.desktopManager.gnome.extraGSettingsOverrides = ''
+  services.desktopManager.gnome.extraGSettingsOverrides = ''
     [org.gnome.mutter]
     experimental-features=['scale-monitor-framebuffer']
   '';

--- a/modules/uncommon/x11.nix
+++ b/modules/uncommon/x11.nix
@@ -1,4 +1,4 @@
 { config, pkgs, ... }:
 {
-  services.xserver.displayManager.gdm.wayland = false;
+  services.displayManager.gdm.wayland = false;
 }


### PR DESCRIPTION
## Summary
- update GNOME/GDM option paths to the new `services.*` locations

## Testing
- `nix flake check --no-write-lock-file` *(fails: `nix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400b9e0df8832f887eaf128b547327