### PR TITLE
Add pandoc and tectonic to LaTeX module

### DIFF
--- a/modules/uncommon/latex.nix
+++ b/modules/uncommon/latex.nix
@@ -9,6 +9,8 @@
       texlive.combined.scheme-full
       texstudio
       inkscape-with-extensions  # for svgs
+      pandoc
+      tectonic
     ];
   };
 }


### PR DESCRIPTION
## Summary
- Include pandoc and tectonic in LaTeX module's user packages

## Testing
- ⚠️ `nix --extra-experimental-features 'nix-command flakes' fmt` (formatter not defined)
- ✅ `nix --extra-experimental-features 'nix-command flakes' flake check`


------
https://chatgpt.com/codex/tasks/task_e_68b5607b11ec832fa5d2bee369de8c9f